### PR TITLE
fix: prevent infinite wait when joining without registering

### DIFF
--- a/client/__test__/pages/Lobby.test.tsx
+++ b/client/__test__/pages/Lobby.test.tsx
@@ -7,7 +7,7 @@ import { Lobby } from '../../src/pages/Lobby';
 import { changeId, changeName, store, updateGamesList } from '../../src/redux';
 
 vi.mock('../../src/socket', () => ({
-  default: { id: 'test-socket', emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+  default: { id: 'test-socket', connected: true, emit: vi.fn(), on: vi.fn(), off: vi.fn(), once: vi.fn() },
 }));
 
 const lobbyGame = {

--- a/client/src/pages/CreateGame.tsx
+++ b/client/src/pages/CreateGame.tsx
@@ -20,6 +20,7 @@ export const CreateGame = () => {
   const user = useSelector((state: RootState) => state.user);
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
+  const [error, setError] = useState<string | null>(null);
 
   const toggleMode = (mode: TGameMode) => {
     setModes((prev) => (prev.includes(mode) ? prev.filter((m) => m !== mode) : [...prev, mode]));
@@ -31,6 +32,8 @@ export const CreateGame = () => {
     const result = await dispatch(createGame({ roomName: roomName.trim(), maxPlayers, modes }));
     if (createGame.fulfilled.match(result)) {
       navigate(`/${roomName.trim()}/${user.name}`);
+    } else {
+      setError(result.payload as string);
     }
   };
 
@@ -77,6 +80,7 @@ export const CreateGame = () => {
             ))}
           </div>
         </div>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
         <div>
           <Button style={{ display: 'block', width: '100%' }} type="submit" disabled={!roomName.trim()}>
             Create

--- a/client/src/pages/Lobby.tsx
+++ b/client/src/pages/Lobby.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '../components/Button';
@@ -15,6 +15,7 @@ export const Lobby = () => {
   const gamesList = useSelector((state: RootState) => state.gamesList);
   const needsAutoJoin = !user.name && !!nav.playerName;
   const joiningRef = useRef(false);
+  const [autoJoinError, setAutoJoinError] = useState('');
 
   useEffect(() => {
     const handleBeforeUnload = () => {
@@ -30,7 +31,23 @@ export const Lobby = () => {
 
   useEffect(() => {
     if (!needsAutoJoin || !nav.playerName) return;
-    dispatch(updatePlayer(nav.playerName));
+
+    const tryUpdatePlayer = () => {
+      dispatch(updatePlayer(nav.playerName!)).then((result) => {
+        if (updatePlayer.rejected.match(result)) {
+          setAutoJoinError(String(result.payload ?? 'Failed to register'));
+        }
+      });
+    };
+
+    if (socket.connected) {
+      tryUpdatePlayer();
+    } else {
+      socket.once('connect', tryUpdatePlayer);
+      return () => {
+        socket.off('connect', tryUpdatePlayer);
+      };
+    }
   }, [needsAutoJoin, nav.playerName]);
 
   useEffect(() => {
@@ -53,6 +70,15 @@ export const Lobby = () => {
   }, [user.name, user.id, nav.roomId, gamesList]);
 
   if (!nav.roomId) return <NotFound />;
+
+  if (autoJoinError) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', height: '100%', gap: '16px' }}>
+        <div>Failed to join: {autoJoinError}</div>
+        <Button onClick={() => navigate('/login-hub')}>Go to Login</Button>
+      </div>
+    );
+  }
 
   if (needsAutoJoin || !gamesList.some((g) => g.id === nav.roomId && g.players.some((p) => p.id === user.id))) {
     return (

--- a/server/src/infrastructure/routes.ts
+++ b/server/src/infrastructure/routes.ts
@@ -72,6 +72,7 @@ export function createRouter(gameManager: GameManager, io: Server) {
     const socketId = req.headers['x-socket-id'] as string;
     const admin = getPlayerFromSocket(socketId);
     if (!admin) return res.status(401).json({ error: 'Player not found' });
+    if (!admin.name) return res.status(400).json({ error: 'You must set a name before creating a game' });
 
     const parsed = createGameSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -94,6 +95,7 @@ export function createRouter(gameManager: GameManager, io: Server) {
     const socketId = req.headers['x-socket-id'] as string;
     const user = getPlayerFromSocket(socketId);
     if (!user) return res.status(401).json({ error: 'Player not found' });
+    if (!user.name) return res.status(400).json({ error: 'You must set a name before joining a game' });
 
     log.info(`${socketId} joining room "${roomName}"`);
     const joined = gameManager.addPlayerToSession(roomName, user);


### PR DESCRIPTION
## Summary
- Server now rejects join/create game requests from players who haven't set a name (returns 400)
- Client Lobby waits for socket connection before attempting auto-join via URL
- Shows error message with "Go to Login" button instead of infinite "Joining..." spinner

Closes #18

## Test plan
- [x] All 206 existing tests pass
- [ ] Navigate to `/:room/:name` without being registered — should show error + login link
- [ ] Navigate to `/:room/:name` while registered — should auto-join as before
- [ ] Join a game from the Online page — should work normally