### PR TITLE
fix: declare winner correctly when player quits or dies from penalty

### DIFF
--- a/server/__tests__/GameSession.test.ts
+++ b/server/__tests__/GameSession.test.ts
@@ -82,6 +82,45 @@ describe('GameSession', () => {
     expect(gameSession.active).toBe(false);
   });
 
+  test('removePlayer during active game declares remaining player as winner', () => {
+    const port1 = createMockPort();
+    const port2 = createMockPort();
+    const admin = new Player(1, 'Admin', 'socket1', port1);
+    const player2 = new Player(2, 'Player2', 'socket2', port2);
+    const gameSession = new GameSession('room1', 4, admin);
+    gameSession.addPlayer(player2);
+    gameSession.active = true;
+    admin.alive = true;
+    player2.alive = true;
+
+    gameSession.removePlayer(1);
+
+    expect(port2.emitGameEnded).toHaveBeenCalledWith('win');
+    expect(gameSession.active).toBe(false);
+  });
+
+  test('removePlayer during active game does not declare winner when multiple players remain', () => {
+    const port1 = createMockPort();
+    const port2 = createMockPort();
+    const port3 = createMockPort();
+    const admin = new Player(1, 'Admin', 'socket1', port1);
+    const player2 = new Player(2, 'Player2', 'socket2', port2);
+    const player3 = new Player(3, 'Player3', 'socket3', port3);
+    const gameSession = new GameSession('room1', 4, admin);
+    gameSession.addPlayer(player2);
+    gameSession.addPlayer(player3);
+    gameSession.active = true;
+    admin.alive = true;
+    player2.alive = true;
+    player3.alive = true;
+
+    gameSession.removePlayer(1);
+
+    expect(port2.emitGameEnded).not.toHaveBeenCalled();
+    expect(port3.emitGameEnded).not.toHaveBeenCalled();
+    expect(gameSession.active).toBe(true);
+  });
+
   test('start sets active and creates shared game loop', () => {
     const admin = new Player(1, 'Admin', 'socket1');
     const gameSession = new GameSession('room1', 4, admin);

--- a/server/src/domain/GameSession.ts
+++ b/server/src/domain/GameSession.ts
@@ -60,11 +60,22 @@ export class GameSession {
   removePlayer(playerId: number) {
     const player = this.players.find((p) => p.id === playerId);
     this.log.info(`Player ${player?.name || playerId} removed`);
-    if (this.active) {
-      this.persistScores();
+    const wasActive = this.active;
+    if (player) {
+      player.alive = false;
+      player.forceStop();
     }
     this.players = this.players.filter((p) => p.id !== playerId);
-    if (!this.players.length) {
+    if (wasActive && this.players.length > 0) {
+      const alivePlayers = this.players.filter((p) => p.alive);
+      if (alivePlayers.length === 1) {
+        this.log.info(`Player ${alivePlayers[0].name || alivePlayers[0].id} wins!`);
+        alivePlayers[0].port?.emitGameEnded('win');
+        this.end();
+      } else if (alivePlayers.length === 0) {
+        this.end();
+      }
+    } else if (!this.players.length) {
       this.end();
     }
   }
@@ -103,7 +114,9 @@ export class GameSession {
     if (linesCleared <= 0) return;
     this.log.info(`${sender.name || sender.id} cleared ${linesCleared} lines, sending ${linesCleared} penalty lines`);
 
+    const wasActive = this.active;
     for (const player of this.players) {
+      if (wasActive && !this.active) break;
       if (player.id !== sender.id && player.alive) {
         const survived = player.board.addPenaltyLines(linesCleared);
         if (!survived) {


### PR DESCRIPTION
removePlayer now triggers win/loss logic during active games — previously a quitting player was silently removed and the last survivor never got a 'win' event. distributePenalty also stops processing after the game ends mid-loop to prevent stale state updates.

Closes #17