### PR TITLE
Remove TGM timing from player loop

### DIFF
--- a/server/__tests__/Board.test.ts
+++ b/server/__tests__/Board.test.ts
@@ -9,27 +9,18 @@ describe('Board', () => {
     expect(board.grid[0]).toHaveLength(10);
   });
 
-  test('setCurrPiece', () => {
+  test('setCurrentPiece', () => {
     const board = new Board();
 
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     expect(board.currPiece).not.toBeNull();
     expect(board.currPiece?.shape).toBe('I');
   });
 
-  test('setCurrPiece with initial rotation (IRS)', () => {
-    const board = new Board();
-
-    board.setCurrPiece('T', 1);
-
-    expect(board.currPiece).not.toBeNull();
-    expect(board.currPiece?.currRotIdx).toBe(1);
-  });
-
   test('moveDown returns true when piece can move', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     const result = board.moveCurrPieceDown();
 
@@ -38,7 +29,7 @@ describe('Board', () => {
 
   test('canMoveCurrPieceDown', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     const result = board.canMoveCurrPieceDown();
 
@@ -47,7 +38,7 @@ describe('Board', () => {
 
   test('clear', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     expect(board.grid[1][4]).toBe('I');
 
     board.clear();
@@ -57,7 +48,7 @@ describe('Board', () => {
 
   test('moveDown changes position', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     board.clear();
 
     board.moveDown();
@@ -68,7 +59,7 @@ describe('Board', () => {
 
   test('lock', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     board.lock();
 
@@ -79,7 +70,7 @@ describe('Board', () => {
   test('draw', () => {
     const board = new Board();
 
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     expect(board.grid[1][4]).toBe('I');
   });
@@ -147,7 +138,7 @@ describe('Board', () => {
 
   test('rotateCurrPiece', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     board.currPiece?.rotate();
 
@@ -156,7 +147,7 @@ describe('Board', () => {
 
   test('canRotateCurrPiece', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     board.clear();
 
     const result = board.canRotateCurrPiece();
@@ -166,7 +157,7 @@ describe('Board', () => {
 
   test('moveHorizontal left', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     board.moveHorizontal('left');
 
@@ -175,7 +166,7 @@ describe('Board', () => {
 
   test('canMoveHorizontal left', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     board.clear();
 
     const result = board.canMoveHorizontal('left');
@@ -185,7 +176,7 @@ describe('Board', () => {
 
   test('moveHorizontal right', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     board.moveHorizontal('right');
 
@@ -194,7 +185,7 @@ describe('Board', () => {
 
   test('canMoveHorizontal right', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     board.clear();
 
     const result = board.canMoveHorizontal('right');
@@ -204,7 +195,7 @@ describe('Board', () => {
 
   test('cannotMoveHorizontal left when blocked', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     board.clear();
     board.grid[1][3] = 'J';
 
@@ -215,7 +206,7 @@ describe('Board', () => {
 
   test('cannotMoveHorizontal right when blocked', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     board.clear();
     board.grid[1][8] = 'J';
 
@@ -226,7 +217,7 @@ describe('Board', () => {
 
   test('pieceCannotMoveDown when blocked', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     board.clear();
     board.grid[2][4] = 'J';
 
@@ -237,7 +228,7 @@ describe('Board', () => {
 
   test('pieceCanMoveDownAfterRotation', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     board.clear();
     board.grid[2][4] = 'J';
     board.rotateCurrPiece();
@@ -249,7 +240,7 @@ describe('Board', () => {
 
   test('lockCurrentPiece nulls currPiece', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     board.lockCurrentPiece();
 
@@ -258,7 +249,7 @@ describe('Board', () => {
 
   test('hardMoveDown locks piece at bottom', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     board.hardMoveDown();
 
@@ -268,7 +259,7 @@ describe('Board', () => {
 
   test('hardMoveDown returns drop distance', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
 
     const distance = board.hardMoveDown();
 
@@ -289,7 +280,7 @@ describe('Board', () => {
 
   test('addPenaltyLines clears and redraws current piece at adjusted position', () => {
     const board = new Board();
-    board.setCurrPiece('T');
+    board.setCurrentPiece('T');
     // Move piece down a few rows
     for (let i = 0; i < 5; i++) {
       board.moveCurrPieceDown();
@@ -307,7 +298,7 @@ describe('Board', () => {
 
   test('addPenaltyLines returns false when piece is crushed', () => {
     const board = new Board();
-    board.setCurrPiece('T');
+    board.setCurrentPiece('T');
     // Piece is at row 0, adding many penalty lines should crush it
 
     const survived = board.addPenaltyLines(19);
@@ -344,21 +335,21 @@ describe('Board', () => {
     expect(payload).toHaveLength(20);
   });
 
-  test('setCurrPiece returns false when top rows are occupied (game over)', () => {
+  test('setCurrentPiece returns false when top rows are occupied (game over)', () => {
     const board = new Board();
     board.grid[1][4] = 'J';
     board.grid[1][5] = 'J';
     board.grid[1][6] = 'J';
     board.grid[1][7] = 'J';
 
-    const result = board.setCurrPiece('I');
+    const result = board.setCurrentPiece('I');
 
     expect(result).toBe(false);
   });
 
   test('canRotateCurrPiece returns false when rotation would exceed grid bottom', () => {
     const board = new Board();
-    board.setCurrPiece('T');
+    board.setCurrentPiece('T');
     board.clear();
     board.currPiece!.currRotIdx = 0;
     board.position = [GRID_HEIGHT - 2, 4];
@@ -370,7 +361,7 @@ describe('Board', () => {
 
   test('canRotateCurrPiece returns false for I-piece when rotation would exceed grid right', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     board.clear();
     board.currPiece!.currRotIdx = 1;
     board.position = [0, 8];
@@ -382,7 +373,7 @@ describe('Board', () => {
 
   test('moveCurrPieceDown does not auto-lock', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     while (board.canMoveCurrPieceDown()) {
       board.clear();
       board.moveDown();
@@ -397,7 +388,7 @@ describe('Board', () => {
 
   test('T-piece wall kicks right when blocked on the left', () => {
     const board = new Board();
-    board.setCurrPiece('T');
+    board.setCurrentPiece('T');
     board.clear();
     board.currPiece!.currRotIdx = 1;
     board.position = [5, 4];
@@ -411,7 +402,7 @@ describe('Board', () => {
 
   test('T-piece wall kicks left when against right wall', () => {
     const board = new Board();
-    board.setCurrPiece('T');
+    board.setCurrentPiece('T');
     board.clear();
     board.position = [5, 8];
     board.rotateCurrPiece();
@@ -422,7 +413,7 @@ describe('Board', () => {
 
   test('I-piece does not wall kick', () => {
     const board = new Board();
-    board.setCurrPiece('I');
+    board.setCurrentPiece('I');
     board.clear();
     board.position = [0, 8];
     board.rotateCurrPiece();
@@ -433,7 +424,7 @@ describe('Board', () => {
 
   test('O-piece does not rotate', () => {
     const board = new Board();
-    board.setCurrPiece('O');
+    board.setCurrentPiece('O');
     const initialRotIdx = board.currPiece!.currRotIdx;
 
     board.rotateCurrPiece();
@@ -443,7 +434,7 @@ describe('Board', () => {
 
   test('S-piece toggles between 2 states', () => {
     const board = new Board();
-    board.setCurrPiece('S');
+    board.setCurrentPiece('S');
     board.clear();
     board.position = [5, 4];
 
@@ -456,7 +447,7 @@ describe('Board', () => {
 
   test('Z-piece toggles between 2 states', () => {
     const board = new Board();
-    board.setCurrPiece('Z');
+    board.setCurrentPiece('Z');
     board.clear();
     board.position = [5, 4];
 
@@ -469,7 +460,7 @@ describe('Board', () => {
 
   test('S-piece wall kicks when near wall', () => {
     const board = new Board();
-    board.setCurrPiece('S');
+    board.setCurrentPiece('S');
     board.clear();
     board.position = [5, 8];
     board.rotateCurrPiece();
@@ -479,7 +470,7 @@ describe('Board', () => {
 
   test('center column rule blocks kick for T-piece', () => {
     const board = new Board();
-    board.setCurrPiece('T');
+    board.setCurrentPiece('T');
     board.clear();
     board.position = [5, 4];
     board.grid[5][5] = 'J';

--- a/server/__tests__/Player.test.ts
+++ b/server/__tests__/Player.test.ts
@@ -102,7 +102,7 @@ describe('Player', () => {
     expect(port.emitNextPiece).toHaveBeenCalled();
   });
 
-  test('frame in ACTIVE state applies gravity', () => {
+  test('tick in ACTIVE state applies gravity', () => {
     const port = createMockPort();
     const player = new Player(1, 'Player1', 'socket1', port);
     const bag = new Tetrominos();
@@ -110,13 +110,13 @@ describe('Player', () => {
     const initialPos = player.board.position[0];
 
     for (let i = 0; i < 100; i++) {
-      player.frame();
+      player.tick();
     }
 
     expect(player.board.position[0]).toBeGreaterThan(initialPos);
   });
 
-  test('frame transitions to LOCK_DELAY when piece hits bottom', () => {
+  test('tick transitions to LOCK_DELAY when piece hits bottom', () => {
     const port = createMockPort();
     const player = new Player(1, 'Player1', 'socket1', port);
     const bag = new Tetrominos();
@@ -124,86 +124,69 @@ describe('Player', () => {
 
     while (player.board.moveCurrPieceDown()) {}
     player.state = PlayerState.ACTIVE;
-    player.gravityAccumulator = 256;
+    player.fallProgress = 256;
 
-    player.frame();
+    player.tick();
 
     expect(player.state).toBe(PlayerState.LOCK_DELAY);
   });
 
-  test('LOCK_DELAY transitions to ARE after 30 frames', () => {
+  test('LOCK_DELAY spawns next piece after 30 ticks', () => {
     const port = createMockPort();
     const player = new Player(1, 'Player1', 'socket1', port);
     const bag = new Tetrominos();
     player.start(bag, vi.fn(), vi.fn(), vi.fn(), vi.fn());
+    const initialBagIndex = player.bagIndex;
 
     while (player.board.moveCurrPieceDown()) {}
     player.state = PlayerState.LOCK_DELAY;
     player.lockDelayCounter = 0;
 
     for (let i = 0; i < 30; i++) {
-      player.frame();
-    }
-
-    expect([PlayerState.ARE, PlayerState.LINE_CLEAR]).toContain(player.state);
-  });
-
-  test('ARE transitions to ACTIVE after 30 frames', () => {
-    const port = createMockPort();
-    const player = new Player(1, 'Player1', 'socket1', port);
-    const bag = new Tetrominos();
-    player.start(bag, vi.fn(), vi.fn(), vi.fn(), vi.fn());
-
-    player.board.hardMoveDown();
-    player.state = PlayerState.ARE;
-    player.areCounter = 0;
-
-    for (let i = 0; i < 30; i++) {
-      player.frame();
+      player.tick();
     }
 
     expect(player.state).toBe(PlayerState.ACTIVE);
+    expect(player.bagIndex).toBe(initialBagIndex + 1);
   });
 
-  test('LINE_CLEAR transitions to ARE after 41 frames', () => {
-    const port = createMockPort();
-    const player = new Player(1, 'Player1', 'socket1', port);
-    const bag = new Tetrominos();
-    player.start(bag, vi.fn(), vi.fn(), vi.fn(), vi.fn());
-
-    for (let col = 0; col < 10; col++) {
-      player.board.grid[20][col] = 'I';
-      player.board.grid[19][col] = 'I';
-    }
-
-    player.pendingLinesCleared = 2;
-    player.state = PlayerState.LINE_CLEAR;
-    player.lineClearCounter = 0;
-
-    for (let i = 0; i < 41; i++) {
-      player.frame();
-    }
-
-    expect(player.state).toBe(PlayerState.ARE);
-  });
-
-  test('LINE_CLEAR calls onLinesCleared for a single line (multiplayer penalty)', () => {
+  test('line clears are resolved without a line clear delay state', () => {
     const port = createMockPort();
     const player = new Player(1, 'Player1', 'socket1', port);
     const bag = new Tetrominos();
     const onLinesCleared = vi.fn();
     player.start(bag, vi.fn(), vi.fn(), onLinesCleared, vi.fn());
 
+    player.board.hardMoveDown();
+    for (let col = 0; col < 10; col++) {
+      player.board.grid[20][col] = 'I';
+      player.board.grid[19][col] = 'I';
+    }
+
+    player.state = PlayerState.LOCK_DELAY;
+    player.lockDelayCounter = 29;
+    player.tick();
+
+    expect(player.state).toBe(PlayerState.ACTIVE);
+    expect(player.score).toBe(2);
+    expect(onLinesCleared).toHaveBeenCalledWith(2);
+  });
+
+  test('single line clear sends multiplayer penalty immediately', () => {
+    const port = createMockPort();
+    const player = new Player(1, 'Player1', 'socket1', port);
+    const bag = new Tetrominos();
+    const onLinesCleared = vi.fn();
+    player.start(bag, vi.fn(), vi.fn(), onLinesCleared, vi.fn());
+
+    player.board.hardMoveDown();
     for (let col = 0; col < 10; col++) {
       player.board.grid[20][col] = 'I';
     }
 
-    player.state = PlayerState.LINE_CLEAR;
-    player.lineClearCounter = 0;
-
-    for (let i = 0; i < 41; i++) {
-      player.frame();
-    }
+    player.state = PlayerState.LOCK_DELAY;
+    player.lockDelayCounter = 29;
+    player.tick();
 
     expect(onLinesCleared).toHaveBeenCalledWith(1);
   });
@@ -289,11 +272,11 @@ describe('Player', () => {
     const keyDownHandlers = (port.onKeyDown as ReturnType<typeof vi.fn>).mock.calls[0][0];
     keyDownHandlers['hardDrop']();
 
-    expect([PlayerState.ARE, PlayerState.LINE_CLEAR]).toContain(player.state);
+    expect(player.state).toBe(PlayerState.ACTIVE);
     expect(port.emitBoard).toHaveBeenCalled();
   });
 
-  test('DAS charges and moves piece after threshold', () => {
+  test('held horizontal movement repeats without a charge tick threshold', () => {
     const port = createMockPort();
     const player = new Player(1, 'Player1', 'socket1', port);
     const bag = new Tetrominos();
@@ -303,11 +286,9 @@ describe('Player', () => {
     const keyDownHandlers = (port.onKeyDown as ReturnType<typeof vi.fn>).mock.calls[0][0];
     keyDownHandlers['left']();
 
-    for (let i = 0; i < 17; i++) {
-      player.frame();
-    }
+    player.tick();
 
-    expect(player.board.position[1]).toBeLessThan(initialCol);
+    expect(player.board.position[1]).toBeLessThan(initialCol - 1);
   });
 
   test('single tap moves piece once', () => {
@@ -325,51 +306,22 @@ describe('Player', () => {
     expect(player.board.position[1]).toBe(initialCol - 1);
   });
 
-  test('IRS spawns piece with rotation', () => {
+  test('scoring adds one point per cleared line', () => {
     const port = createMockPort();
     const player = new Player(1, 'Player1', 'socket1', port);
     const bag = new Tetrominos();
     player.start(bag, vi.fn(), vi.fn(), vi.fn(), vi.fn());
 
     player.board.hardMoveDown();
-
-    player.irsRotation = true;
-    player.state = PlayerState.ARE;
-    player.areCounter = 29;
-
-    player.frame();
-
-    expect(player.state).toBe(PlayerState.ACTIVE);
-  });
-
-  test('scoring applies formula on line clear', () => {
-    const port = createMockPort();
-    const player = new Player(1, 'Player1', 'socket1', port);
-    const bag = new Tetrominos();
-    player.start(bag, vi.fn(), vi.fn(), vi.fn(), vi.fn());
-
     for (let col = 0; col < 10; col++) {
       player.board.grid[20][col] = 'I';
     }
 
-    player.pendingLinesCleared = 1;
-    player.combo = 1;
-    player.softDropFrames = 0;
-    player.state = PlayerState.LINE_CLEAR;
-    player.lineClearCounter = 40;
+    player.state = PlayerState.LOCK_DELAY;
+    player.lockDelayCounter = 29;
+    player.tick();
 
-    player.frame();
-
-    expect(player.score).toBeGreaterThan(0);
-  });
-
-  test('combo increases with consecutive line clears', () => {
-    const player = new Player(1, 'Player1', 'socket1');
-    player.combo = 1;
-
-    expect(1 + 2 * 1 - 2).toBe(1);
-    expect(1 + 2 * 2 - 2).toBe(3);
-    expect(3 + 2 * 1 - 2).toBe(3);
+    expect(player.score).toBe(1);
   });
 
   test('sendBoard emits board payload and spectrum', () => {
@@ -404,10 +356,9 @@ describe('Player', () => {
     const initialPos = player.board.position[0];
 
     player.heldKeys['down'] = true;
-    player.frame();
+    player.tick();
 
     expect(player.board.position[0]).toBeGreaterThan(initialPos);
-    expect(player.softDropFrames).toBe(1);
   });
 
   test('key release handlers work correctly', () => {
@@ -421,7 +372,6 @@ describe('Player', () => {
 
     keyDownHandlers['left']();
     expect(player.heldKeys['left']).toBe(true);
-    expect(player.dasDirection).toBe('left');
 
     keyUpHandlers['left']();
     expect(player.heldKeys['left']).toBe(false);
@@ -436,27 +386,26 @@ describe('Player', () => {
     const keyDownHandlers = (port.onKeyDown as ReturnType<typeof vi.fn>).mock.calls[0][0];
     keyDownHandlers['rotate']();
 
-    player.frame();
+    player.tick();
 
     expect(player.heldKeys['rotate']).toBe(false);
   });
 
-  test('ARE state ends game when no piece can be placed', () => {
+  test('game ends when the next piece cannot be placed', () => {
     const port = createMockPort();
     const player = new Player(1, 'Player1', 'socket1', port);
     const bag = new Tetrominos();
     const onStop = vi.fn();
     player.start(bag, vi.fn(), onStop, vi.fn(), vi.fn());
 
-    for (let col = 0; col < 10; col++) {
-      player.board.grid[0][col] = 'J';
+    player.board.hardMoveDown();
+    for (let col = 4; col <= 7; col++) {
       player.board.grid[1][col] = 'J';
     }
 
-    player.state = PlayerState.ARE;
-    player.areCounter = 29;
-
-    player.frame();
+    player.state = PlayerState.LOCK_DELAY;
+    player.lockDelayCounter = 29;
+    player.tick();
 
     expect(player.alive).toBe(false);
     expect(onStop).toHaveBeenCalled();

--- a/server/src/domain/Board.ts
+++ b/server/src/domain/Board.ts
@@ -17,11 +17,8 @@ export class Board {
   currPiece: Piece | null = null;
   position: [number, number] = [0, 0];
 
-  setCurrPiece(tetromino: TTetromino, initialRotation?: number) {
+  setCurrentPiece(tetromino: TTetromino) {
     this.currPiece = new Piece(tetromino, Shapes[tetromino]);
-    if (initialRotation !== undefined) {
-      this.currPiece.currRotIdx = initialRotation % this.currPiece.configs.length;
-    }
     this.position = [0, 4];
     const canPlace = this.canPlaceCurrPiece({});
     if (canPlace) this.draw();

--- a/server/src/domain/Game.ts
+++ b/server/src/domain/Game.ts
@@ -4,8 +4,8 @@ import { Player } from './Player.js';
 import { Tetrominos } from './Tetrominos.js';
 import { type ScorePort } from './ports.js';
 
-const FRAME_MS = 1000 / 60;
-const BOARD_EMIT_INTERVAL = 3; // emit every 3 frames (~20fps)
+const TICK_MS = 1000 / 60;
+const BOARD_EMIT_INTERVAL_TICKS = 3; // emit every 3 ticks (~20fps)
 const NOOP_SCORE_PORT: ScorePort = {
   saveScores: async () => {},
 };
@@ -24,7 +24,7 @@ export class Game {
   active = false;
   private log;
   private loopInterval: ReturnType<typeof setInterval> | null = null;
-  private frameCount = 0;
+  private tickCount = 0;
 
   readonly id: string;
   readonly maxPlayers: number;
@@ -167,12 +167,12 @@ export class Game {
   }
 
   private tick() {
-    this.frameCount++;
-    const shouldEmitBoard = this.frameCount % BOARD_EMIT_INTERVAL === 0;
+    this.tickCount++;
+    const shouldEmitBoard = this.tickCount % BOARD_EMIT_INTERVAL_TICKS === 0;
 
     for (const p of this.players) {
       if (p.alive) {
-        p.frame();
+        p.tick();
         if (shouldEmitBoard) {
           p.sendBoard();
         }
@@ -183,7 +183,7 @@ export class Game {
   start() {
     this.log.info(`Started with ${this.players.length} players`);
     this.active = true;
-    this.frameCount = 0;
+    this.tickCount = 0;
 
     for (const p of this.players) {
       p.start(
@@ -196,7 +196,7 @@ export class Game {
       );
     }
 
-    this.loopInterval = setInterval(() => this.tick(), FRAME_MS);
+    this.loopInterval = setInterval(() => this.tick(), TICK_MS);
   }
 
   restart() {

--- a/server/src/domain/Player.ts
+++ b/server/src/domain/Player.ts
@@ -6,38 +6,35 @@ import { PlayerPort } from './ports.js';
 
 export enum PlayerState {
   IDLE = 'IDLE',
-  ARE = 'ARE',
   ACTIVE = 'ACTIVE',
   LOCK_DELAY = 'LOCK_DELAY',
-  LINE_CLEAR = 'LINE_CLEAR',
 }
 type PlayerPayload = { id: number; name: string; alive: boolean; score: number };
+type EnabledModes = Record<TGameMode, boolean>;
 
-const LOCK_DELAY_FRAMES = 30;
-const ARE_FRAMES = 30;
-const LINE_CLEAR_FRAMES = 41;
-const DAS_CHARGE_FRAMES = 16;
+const LOCK_DELAY_TICKS = 30;
+const FALL_PROGRESS_PER_ROW = 256;
+const NORMAL_FALL_PROGRESS_PER_TICK = 4;
+const FAST_FALL_PROGRESS_PER_TICK = 8;
+const SOFT_DROP_FALL_PROGRESS_PER_TICK = FALL_PROGRESS_PER_ROW;
 
 export class Player {
   board = new Board();
   alive = true;
   score = 0;
-  combo = 1;
   state: PlayerState = PlayerState.IDLE;
 
-  gravityAccumulator = 0;
-  softDropFrames = 0;
+  fallProgress = 0;
   lockDelayCounter = 0;
-  areCounter = 0;
-  lineClearCounter = 0;
-  pendingLinesCleared = 0;
 
   heldKeys: Record<string, boolean> = {};
-  dasDirection: 'left' | 'right' | null = null;
-  dasCounter = 0;
-  irsRotation = false;
 
   modes: TGameMode[] = [];
+  enabledModes: EnabledModes = {
+    fast: false,
+    inverted: false,
+    easy: false,
+  };
   bag!: Tetrominos;
   bagIndex = 0;
   notify: (data: PlayerPayload) => void = () => {};
@@ -63,9 +60,7 @@ export class Player {
     const { current, next } = this.bag.getPiece(this.bagIndex);
     this.port?.emitNextPiece(next, Shapes[next][0]);
     this.bagIndex++;
-    const initialRotation = this.irsRotation ? 1 : undefined;
-    this.irsRotation = false;
-    return this.board.setCurrPiece(current, initialRotation);
+    return this.board.setCurrentPiece(current);
   }
 
   start(
@@ -79,19 +74,12 @@ export class Player {
     if (!this.port) return;
 
     this.modes = modes;
+    this.enabledModes = this.toEnabledModes(modes);
     this.score = 0;
-    this.combo = 1;
     this.bagIndex = 0;
-    this.softDropFrames = 0;
-    this.gravityAccumulator = 0;
+    this.fallProgress = 0;
     this.lockDelayCounter = 0;
-    this.areCounter = 0;
-    this.lineClearCounter = 0;
-    this.pendingLinesCleared = 0;
     this.heldKeys = {};
-    this.dasDirection = null;
-    this.dasCounter = 0;
-    this.irsRotation = false;
     this.notify = notify;
     this.onStop = onStop;
     this.onLinesCleared = onLinesCleared;
@@ -109,8 +97,22 @@ export class Player {
     this.registerKeyHandlers();
   }
 
+  private toEnabledModes(modes: TGameMode[]): EnabledModes {
+    const enabledModes: EnabledModes = {
+      fast: false,
+      inverted: false,
+      easy: false,
+    };
+
+    for (const mode of modes) {
+      enabledModes[mode] = true;
+    }
+
+    return enabledModes;
+  }
+
   private registerKeyHandlers() {
-    const inverted = this.modes.includes('inverted');
+    const inverted = this.enabledModes.inverted;
     const leftDir = inverted ? 'right' : 'left';
     const rightDir = inverted ? 'left' : 'right';
 
@@ -120,42 +122,23 @@ export class Player {
       },
       left: () => {
         this.heldKeys['left'] = true;
-        this.dasDirection = leftDir;
-        this.dasCounter = 0;
         if (this.state === PlayerState.ACTIVE || this.state === PlayerState.LOCK_DELAY) {
           this.board.moveHorizontal(leftDir);
         }
       },
       right: () => {
         this.heldKeys['right'] = true;
-        this.dasDirection = rightDir;
-        this.dasCounter = 0;
         if (this.state === PlayerState.ACTIVE || this.state === PlayerState.LOCK_DELAY) {
           this.board.moveHorizontal(rightDir);
         }
       },
       rotate: () => {
         this.heldKeys['rotate'] = true;
-        if (this.state === PlayerState.ARE) {
-          this.irsRotation = true;
-        }
       },
       hardDrop: () => {
         if (this.state === PlayerState.ACTIVE || this.state === PlayerState.LOCK_DELAY) {
           this.board.hardMoveDown();
-          const cleared = this.board.markCompleteRows();
-          if (cleared > 0) {
-            this.pendingLinesCleared = cleared;
-            this.lineClearCounter = 0;
-            this.state = PlayerState.LINE_CLEAR;
-          } else {
-            this.combo = 1;
-            this.areCounter = 0;
-            this.state = PlayerState.ARE;
-          }
-          this.sendBoard();
-          this.sendScore();
-          this.notify(this.toPayload());
+          this.finishTurn();
         }
       },
     };
@@ -166,21 +149,12 @@ export class Player {
       },
       left: () => {
         this.heldKeys['left'] = false;
-        if (this.dasDirection === leftDir) {
-          this.dasDirection = this.heldKeys['right'] ? rightDir : null;
-          this.dasCounter = 0;
-        }
       },
       right: () => {
         this.heldKeys['right'] = false;
-        if (this.dasDirection === rightDir) {
-          this.dasDirection = this.heldKeys['left'] ? leftDir : null;
-          this.dasCounter = 0;
-        }
       },
       rotate: () => {
         this.heldKeys['rotate'] = false;
-        this.irsRotation = false;
       },
     };
 
@@ -188,51 +162,40 @@ export class Player {
     this.port!.onKeyUp(this.keyUpHandlers);
   }
 
-  frame() {
-    if (this.state !== PlayerState.IDLE && this.dasDirection) {
-      this.dasCounter++;
-    }
-
+  tick() {
     switch (this.state) {
       case PlayerState.ACTIVE:
-        this.frameActive();
+        this.tickActive();
         break;
       case PlayerState.LOCK_DELAY:
-        this.frameLockDelay();
-        break;
-      case PlayerState.LINE_CLEAR:
-        this.frameLineClear();
-        break;
-      case PlayerState.ARE:
-        this.frameAre();
+        this.tickLockDelay();
         break;
     }
   }
 
-  private frameActive() {
+  private tickActive() {
     if (this.heldKeys['rotate']) {
       this.board.rotateCurrPiece();
       this.heldKeys['rotate'] = false;
     }
 
-    this.applyDasMovement();
+    this.applyHeldHorizontalMovement();
 
-    this.gravityAccumulator += this.modes.includes('fast') ? 8 : 4;
+    this.fallProgress += this.enabledModes.fast ? FAST_FALL_PROGRESS_PER_TICK : NORMAL_FALL_PROGRESS_PER_TICK;
 
     if (this.heldKeys['down']) {
-      this.gravityAccumulator += 256;
-      this.softDropFrames++;
+      this.fallProgress += SOFT_DROP_FALL_PROGRESS_PER_TICK;
     }
 
-    while (this.gravityAccumulator >= 256) {
-      this.gravityAccumulator -= 256;
+    while (this.fallProgress >= FALL_PROGRESS_PER_ROW) {
+      this.fallProgress -= FALL_PROGRESS_PER_ROW;
       this.board.clear();
       if (this.board.canMoveCurrPieceDown()) {
         this.board.moveDown();
         this.board.draw();
       } else {
         this.board.draw();
-        this.gravityAccumulator = 0;
+        this.fallProgress = 0;
         this.lockDelayCounter = 0;
         this.state = PlayerState.LOCK_DELAY;
         return;
@@ -240,91 +203,61 @@ export class Player {
     }
   }
 
-  private frameLockDelay() {
+  private tickLockDelay() {
     if (this.heldKeys['rotate']) {
       this.board.rotateCurrPiece();
       this.heldKeys['rotate'] = false;
     }
 
-    this.applyDasMovement();
+    this.applyHeldHorizontalMovement();
 
     this.board.clear();
     if (this.board.canMoveCurrPieceDown()) {
       this.board.draw();
       this.state = PlayerState.ACTIVE;
-      this.gravityAccumulator = 0;
+      this.fallProgress = 0;
       return;
     }
     this.board.draw();
 
     this.lockDelayCounter++;
-    if (this.lockDelayCounter >= LOCK_DELAY_FRAMES) {
+    if (this.lockDelayCounter >= LOCK_DELAY_TICKS) {
       this.board.lockCurrentPiece();
-      const cleared = this.board.markCompleteRows();
-      if (cleared > 0) {
-        this.pendingLinesCleared = cleared;
-        this.lineClearCounter = 0;
-        this.state = PlayerState.LINE_CLEAR;
-      } else {
-        this.combo = 1;
-        this.areCounter = 0;
-        this.state = PlayerState.ARE;
-      }
-      this.sendBoard();
-      this.sendScore();
-      this.notify(this.toPayload());
+      this.finishTurn();
     }
   }
 
-  private frameLineClear() {
-    this.lineClearCounter++;
-    if (this.lineClearCounter >= LINE_CLEAR_FRAMES) {
-      const cleared = this.board.removeMarkedRows();
-      this.applyScoring(cleared);
-      if (cleared > 0) this.onLinesCleared(cleared);
-      this.sendBoard();
-      this.sendScore();
-      this.notify(this.toPayload());
-      this.areCounter = 0;
-      this.state = PlayerState.ARE;
+  private applyHeldHorizontalMovement() {
+    if (this.heldKeys['left']) {
+      this.board.moveHorizontal(this.enabledModes.inverted ? 'right' : 'left');
     }
-  }
-
-  private frameAre() {
-    if (this.heldKeys['rotate']) {
-      this.irsRotation = true;
-    }
-
-    this.areCounter++;
-    if (this.areCounter >= ARE_FRAMES) {
-      this.softDropFrames = 0;
-      this.gravityAccumulator = 0;
-
-      if (!this.handleNextPiece()) {
-        this.alive = false;
-        this.stop();
-        return;
-      }
-
-      this.applyDasMovement();
-
-      this.state = PlayerState.ACTIVE;
-      this.sendBoard();
-      this.notify(this.toPayload());
-    }
-  }
-
-  private applyDasMovement() {
-    if (!this.dasDirection) return;
-    if (this.dasCounter >= DAS_CHARGE_FRAMES) {
-      this.board.moveHorizontal(this.dasDirection);
+    if (this.heldKeys['right']) {
+      this.board.moveHorizontal(this.enabledModes.inverted ? 'left' : 'right');
     }
   }
 
   private applyScoring(linesCleared: number) {
-    this.combo = this.combo + 2 * linesCleared - 2;
-    const bravo = this.board.isBoardEmpty() ? 4 : 1;
-    this.score += (1 + this.softDropFrames) * linesCleared * this.combo * bravo;
+    this.score += linesCleared;
+  }
+
+  private finishTurn() {
+    const cleared = this.board.removeMarkedRows();
+    this.applyScoring(cleared);
+    if (cleared > 0) this.onLinesCleared(cleared);
+
+    this.fallProgress = 0;
+    this.lockDelayCounter = 0;
+
+    if (!this.handleNextPiece()) {
+      this.alive = false;
+      this.stop();
+      return;
+    }
+
+    this.state = PlayerState.ACTIVE;
+    this.sendBoard();
+    this.sendScore();
+    this.notify(this.toPayload());
   }
 
   stop() {
@@ -353,7 +286,7 @@ export class Player {
   }
 
   sendBoard() {
-    this.port?.emitBoard(this.board.toPayload(this.modes.includes('easy')));
+    this.port?.emitBoard(this.board.toPayload(this.enabledModes.easy));
     this.onBoardUpdate(this.id, this.board.getSpectrum());
   }
 


### PR DESCRIPTION
## Summary
- remove TGM-inspired ARE, line clear delay, IRS, DAS charge, combo/bravo, and soft-drop scoring from Player
- use immediate line clear resolution with explicit line clear scores
- rename the player loop to tick and cache mode flags for O(1) access

## Tests
- npm test
- npm run build:server